### PR TITLE
Restyle package page, fix markup errors, remove duplicate CSS include

### DIFF
--- a/lib/packagify.js
+++ b/lib/packagify.js
@@ -25,7 +25,7 @@ function packagify(data) {
     , author: author_name
     , author_email: author_email
     , default_avatar: encodeURIComponent('http://i.imgur.com/QgNMMnd.png')
-    , keywords: current_data.keywords || []
+    , keywords: (current_data.keywords || []).join(', ')
     , author_avatar: gravatarify(author_email)
     , last_modified: dateify((data.time || {}).modified)
     , created: dateify((data.time || {}).created)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,9 +1,49 @@
-body {
-  background: #f8f8f8;
-  color: #212121;
-  font: 13px Lucida Grande, sans-serif;
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+object, iframe, blockquote, pre, abbr, address, cite, code, del, dfn, img, ins, kbd, q, samp, small, sub, sup, var, b, i, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figcaption, figure, footer, header, hgroup, menu, nav, section, summary, time, mark, audio, video {
   margin: 0;
   padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+body {
+  background: #fdfdfd;
+  color: #212121;
+  font: 16px Lucida Grande, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+h1 {
+  color: #444;
+}
+
+h2 {
+  color: #444;
+  font-size: 2em;
+  font-family: 'Source Sans Pro', 'Lucida Grande', sans-serif;
+}
+
+h3 {
+  color: #444;
+  font-size: 1.5em;
+  font-family: 'Source Sans Pro', 'Lucida Grande', sans-serif;
+}
+
+h4 {
+  font-size: 1.25em;
+}
+
+code {
+  font-family: monospace;
 }
 
 a {
@@ -29,19 +69,61 @@ a:visited {
 }
 
 header h1 {
-  color: #f8f8f8;
+  color: #fff4e9;
+  font-weight: 400;
+  font-family: Tahoma, Verdana, Segoe, sans-serif;
+  letter-spacing: -1px;
   margin: 0;
-  border: 0;
   padding: 0;
+  padding-left: 10px;
+  text-shadow: 0px 0px 3px rgba(100, 100, 100, .3);
 }
 
 header {
-  background: #eaeaea;
-  padding: 2em 0 0.5em 1em;
+  background: #fe9013;
+  background: -moz-linear-gradient(top, rgba(250,167,65,1) 0%, rgba(254,144,19,1) 95%, rgba(229,147,54,1) 97%, rgba(229,147,54,1) 100%);
+  background: -webkit-gradient(left top, left bottom, color-stop(0%, rgba(250,167,65,1)), color-stop(95%, rgba(254,144,19,1)), color-stop(97%, rgba(229,147,54,1)), color-stop(100%, rgba(229,147,54,1)));
+  background: -webkit-linear-gradient(top, rgba(250,167,65,1) 0%, rgba(254,144,19,1) 95%, rgba(229,147,54,1) 97%, rgba(229,147,54,1) 100%);
+  background: -o-linear-gradient(top, rgba(250,167,65,1) 0%, rgba(254,144,19,1) 95%, rgba(229,147,54,1) 97%, rgba(229,147,54,1) 100%);
+  background: -ms-linear-gradient(top, rgba(250,167,65,1) 0%, rgba(254,144,19,1) 95%, rgba(229,147,54,1) 97%, rgba(229,147,54,1) 100%);
+  background: linear-gradient(to bottom, rgba(250,167,65,1) 0%, rgba(254,144,19,1) 95%, rgba(229,147,54,1) 97%, rgba(229,147,54,1) 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#faa741', endColorstr='#e59336', GradientType=0 );
+
+  padding: 10px 0;
 }
 
 footer {
   background: #eaeaea;
-  padding: 2em 1em 0.5em 1em;
+  padding: 1em;
   text-align: right;
+  color: #888;
+  font-size: .9em;
+}
+
+ul {
+  list-style: none;
+  margin: 25px;
+  margin-right: 0;
+  padding: 0;
+}
+
+ul li {
+  list-style: disc;
+  margin: 5px 0;
+}
+
+@media (min-width: 1024px) {
+  header {
+    padding: 5px 0;
+  }
+
+  header h1 {
+    max-width: 1150px;
+    margin: 0 auto;
+    padding-left: 25px;
+  }
+
+  body {
+    font-size: 14px;
+  }
 }

--- a/static/css/package.css
+++ b/static/css/package.css
@@ -1,36 +1,61 @@
 img.author-avatar {
-  max-width: 30px
+  max-width: 90px
 }
 
 .package-container {
-  margin: 0 2em;
-  padding: 1em 2em;
+  /*clearfix*/
+  overflow: auto;
+  zoom: 1;
+
+  padding: 20px;
 }
 
 .main-header {
   font-size: 3em;
-  border-bottom: dashed #eaeaea;
+  font-weight: 200;
+  letter-spacing: -2px;
+  margin: 0;
+  margin-left: -0.1em;
 }
 
-.package-info {
-  font-size: 14px;
+.package-description {
+  font-weight: 100;
+  font-family: 'Century Gothic', CenturyGothic, AppleGothic, sans-serif;
+  margin-top: 0;
+}
+
+.package-detail {
+  color: #444;
+  display: block;
+  font-weight: 100;
+  font-size: 1.25em;
+  font-family: 'Source Sans Pro', 'Lucida Grande', sans-serif;
+}
+
+section {
+  margin-bottom: 2em;
+}
+
+.readme-link:hover {
+  text-decoration: none;
+  border: none;
 }
 
 .package-readme {
-  max-width: 768px;
+  line-height: 1.4;
+  max-width: 100%;
+  overflow: hidden;
+  overflow-x: auto;
 }
 
 .package-readme pre {
   padding: 1em;
   border-left: 2px solid #d8d8d8;
-  background: #eaeaea;
+  background: #ececec;
 }
 
 .package-info {
-  width: 768px;
   margin-bottom: 2em;
-  border-collapse: collapse;
-  border-spacing: 0;
 }
 
 .package-info td {
@@ -46,6 +71,10 @@ img.author-avatar {
   margin-right: 1em;
 }
 
+.repository-link {
+     word-break: break-word;
+}
+
 .package-readme h1 {
   margin-top: 0px;
   padding-bottom: 5px;
@@ -58,18 +87,79 @@ img.author-avatar {
 .package-readme h4,
 .package-readme h5,
 .package-readme h6 {
+  color: #444;
+  font-family: 'Source Sans Pro', 'Lucida Grande', sans-serif;
   padding-top: 0.5em;
 }
 
 .package-dependents,
-.package-dependencies,
-.package-keywords {
-  list-style: square;
+.package-dependencies {
+  list-style: disc;
   margin: 0;
-  padding: 0 1.25em;
+  padding-left: 50px;
 }
 
 .package-dependencies li,
 .package-keywords li {
   margin: 0.25em 0;
+}
+
+.package-readme li {
+  line-height: 1.25;
+}
+
+.package-readme code {
+  background-color: #ececec;
+  font-size: 1em;
+  font-family: Consolas, "Liberation Mono", Menlo, Monaco, Courier, monospace;
+}
+
+.package-readme img {
+  max-width: 100%;
+}
+
+pre {
+  max-width: 100%;
+  overflow: hidden;
+  overflow-x: auto;
+}
+
+@media (min-width: 1024px) {
+  .package-container {
+    margin: 0 auto;
+    max-width: 1150px;
+    padding: 15px 30px;
+  }
+
+  .package-heading,
+  .package-readme {
+    width: 75%;
+    float: left;
+  }
+
+  .package-readme {
+    overflow: auto;
+    padding-right: 10px;
+    max-width: 768px;
+  }
+
+  .main-header {
+    margin-top: 15px;
+  }
+
+  .package-info {
+    float: right;
+    margin: 0;
+    margin-top: 60px;
+    width: 25%;
+  }
+
+  .package-dependents,
+  .package-dependencies {
+    padding: 0 1.5em;
+  }
+
+  .readme-header {
+    display: none;
+  }
 }

--- a/templates/package.html
+++ b/templates/package.html
@@ -1,94 +1,92 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>{{ name }} &lt; {{ config.registry }}</title>
     {{>head}}
-    <link rel="stylesheet" href="../css/main.css">
     <link rel="stylesheet" href="../css/package.css">
     <link rel="stylesheet" href="../css/github.css">
   </head>
-    {{>header}}
   <body>
+    {{>header}}
     <div class="package-container">
-      <h1 class="main-header">{{ name }}</h1>
+      <div class="package-heading">
+        <h1 class="main-header">{{ name }}</h1>
+        <h2 class="package-description">
+          {{ description }}
+        </h2>
+      </div>
 
-      <p>
-        {{ description }}
-      </p>
+      <div class="package-info">
+        <section>
+          <span class="package-detail">Version <strong>{{ version }}</strong></span>
+          <span class="package-detail">Published <strong>{{last_modified}}</strong></span>
+        </section>
 
-      <table class="package-info">
-        <tr>
-          <td><strong>Author</strong></td>
-          <td><img class="author-avatar" src="{{ author_avatar }}?d={{ default_avatar }}"> {{ author }}</td>
-        </tr>
-        <tr>
-          <td><strong>Version</strong></td>
-          <td>{{ version }}</td>
-        </tr>
         {{#dependencies.length}}
-        <tr>
-          <td><strong>Dependencies</strong></td>
-          <td>
-            <ul class="package-dependencies">
-              {{#dependencies}}
-              <li>
-                <a href="../package/{{ name }}">{{ name }}</a>
-                @ {{ version }}
-              </li>
-              {{/dependencies}}
-            </ul>
-          </td>
-        </tr>
+        <section>
+          <h3>Dependencies</h3>
+          <ul class="package-dependencies">
+            {{#dependencies}}
+            <li>
+              <a href="../package/{{ name }}">{{ name }}</a> @ {{ version }}
+            </li>
+            {{/dependencies}}
+          </ul>
+        </section>
         {{/dependencies.length}}
-        {{#dependents.list.length}}
-        <tr>
-          <td><strong>Dependents</strong></td>
-          <td>
-            <ul class="package-dependents">
-              {{#dependents.list}}
-              <li>
-                <a href="../package/{{.}}">{{.}}</a>
-              </li>
-              {{/dependents.list}}
-            </ul>
-            {{#dependents.remain}}
-            ... and <a href="../browse/depended/{{ name }}">{{ dependents.remain }} more</a>
-            {{/dependents.remain}}
-          </td>
-        </tr>
-        {{/dependents.list.length}}
-        <tr>
-          <td><strong>Repository</strong></td>
-          <td>
-            <code><a href="{{ repository_www }}">{{ repository }}</a></code>
-          </td>
-        </tr>
-        {{#keywords.length}}
-        <tr>
-          <td><strong>Keywords</strong></td>
-          <td>
-            <ul class="package-keywords">
-              {{#keywords}}
-              <li>{{ . }}</li>
-              {{/keywords}}
-            </ul>
-          </td>
-        </tr>
-        {{/keywords.length}}
-        {{#created}}
-        <tr>
-          <td><strong>Created</strong></td>
-          <td>{{ created }}
-        </tr>
-        {{/created}}
-        {{#last_modified}}
-        <tr>
-          <td><strong>Last Updated</strong></td>
-          <td>{{ last_modified }}</td>
-        </tr>
-        {{/last_modified}}
-      </table>
 
-      <h1 class="main-header"><a href="#readme">#</a> README</h1>
+        {{#dependents.list.length}}
+        <section>
+          <h3>Dependents</h3>
+
+          <ul class="package-dependents">
+            {{#dependents.list}}
+            <li>
+              <a href="../package/{{.}}">{{.}}</a>
+            </li>
+            {{/dependents.list}}
+          </ul>
+          {{#dependents.remain}}
+          <p>
+            &hellip; and
+            <a href="../browse/depended/{{ name }}">
+            {{ dependents.remain }} more
+            </a>
+          </p>
+          {{/dependents.remain}}
+        </section>
+        {{/dependents.list.length}}
+
+        <section>
+          <h3>Author</h3>
+          <img class="author-avatar" src="{{ author_avatar }}?d={{ default_avatar }}" alt="{{author}}">
+          <p><span class="package-detail">{{ author }}</span></p>
+        </section>
+
+        <section>
+          <span class="package-detail">
+            <strong><a href="{{ repository_www }}" class="repository-link">{{ repository }}</a></strong>
+          </span>
+        </section>
+
+        {{#keywords.length}}
+        <section>
+          <span class="package-detail">
+            Keywords: <strong>{{keywords}}</strong>
+          </span>
+        </section>
+        {{/keywords.length}}
+
+        {{#created}}
+        <section>
+          <span class="package-detail">
+            Created <strong>{{ created }}</strong>
+          </span>
+        </section>
+        {{/created}}
+      </div>
+
+      <h1 class="readme-header main-header"><a href="#readme">README</a></h1>
       <div class="package-readme" id="readme">
         {{{ readme }}}
       </div>


### PR DESCRIPTION
This PR restyles the package page. While I was doing that, I also fixed some HTML validation errors, and removed a double-include of the main.css stylesheet.

![screen shot 2014-12-14 at 8 55 32 pm](https://cloud.githubusercontent.com/assets/3019349/5431055/edb0536c-83d3-11e4-82a2-e82515046166.png)
